### PR TITLE
Hide rating if it's less than 0.1

### DIFF
--- a/components/BeerItem.vue
+++ b/components/BeerItem.vue
@@ -13,7 +13,9 @@
           {{ beer.style.name }}
           <span v-if="abvFixed" class="beer-abv">{{ abvFixed }}%</span>
         </div>
-        <div v-if="rating" class="beer-rating">{{ rating }}</div>
+        <div v-if="rating !== null && rating >= 0.1" class="beer-rating">
+          {{ rating }}
+        </div>
       </div>
     </div>
     <b-collapse


### PR DESCRIPTION
This way untappd beers with insufficient ratings to have a real
number don't get penalized.

I used 0.1 because it's impossible to rate a beer less than 0.25 on Untappd.

On hsv.beer:
![image](https://user-images.githubusercontent.com/7773256/63613618-c90fa700-c5a6-11e9-93ee-ad32fa852ef3.png)

On master:
![image](https://user-images.githubusercontent.com/7773256/63613666-de84d100-c5a6-11e9-9b5e-fadee0898099.png)


After:
![image](https://user-images.githubusercontent.com/7773256/63613635-d036b500-c5a6-11e9-93de-ab2b7c4bd208.png)
