### PR TITLE
Use a venue's logo if present in the API

### DIFF
--- a/components/VenueItem.vue
+++ b/components/VenueItem.vue
@@ -2,7 +2,7 @@
   <li class="venue" :class="{ active: visible }">
     <div class="venue-intro">
       <div class="venue-logo">
-        <img :src="logo" />
+        <b-img-lazy :src="logo" blank-src="/img/beernotfound.jpg" />
       </div>
       <div class="venue-info">
         <nuxt-link :to="venue.slug" class="venue-link">


### PR DESCRIPTION
Title says it all.

Also makes https://github.com/hsv-dot-beer/hsvdotbeer/issues/251 more pressing.

I propose we fix them ourselves and add them as static assets in the backend.