### PR TITLE
Format venue phone numbers and websites for prettier display

### DIFF
--- a/components/VenueModal.vue
+++ b/components/VenueModal.vue
@@ -117,7 +117,6 @@ export default {
     },
     formattedPhone () {
       const regex = /(\d\d\d)(\d\d\d)(\d\d\d\d)/
-      console.log('wheeeeee')
       if (this.venue.phone_number && this.venue.phone_number.match(regex)) {
         return this.venue.phone_number.replace(regex, '($1) $2-$3')
       }


### PR DESCRIPTION
Fixes #42.

Before:
![image](https://user-images.githubusercontent.com/7773256/65293975-b0050200-db22-11e9-9aac-2578f4b65167.png)

After:
![image](https://user-images.githubusercontent.com/7773256/65293956-9cf23200-db22-11e9-92fc-590f32f91a80.png)


Also does a `yarn lint --fix` run.